### PR TITLE
minor fix to app ID in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ edge-node-manager compatible firmware for the micro:bit
  - Clone this repository to your local workspace
  - Add the dependent application `resin remote` to your local workspace
  - Retrieve the dependent application ID from the Resin dashboard, for example: If your dependent application URL is
- `https://dashboard.staging.io/apps/13829/devices` the ID is `14495`
+ `https://dashboard.staging.io/apps/13829/devices` the ID is `13829`
  - Change [line 3](https://github.com/resin-io-projects/micro-bit/blob/master/source/main.cpp#L3) in `source/main.cpp` `#define APP_ID 1234567890` to point to your dependent application ID e.g. `#define APP_ID 14495`
  - Run the provisioning script `$ ./provision.sh`, this will generate the initial firmware `micro-bit-combined.hex`
  - Connect the micro:bit to your computer using a USB cable

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ edge-node-manager compatible firmware for the micro:bit
  - Add the dependent application `resin remote` to your local workspace
  - Retrieve the dependent application ID from the Resin dashboard, for example: If your dependent application URL is
  `https://dashboard.staging.io/apps/13829/devices` the ID is `13829`
- - Change [line 3](https://github.com/resin-io-projects/micro-bit/blob/master/source/main.cpp#L3) in `source/main.cpp` `#define APP_ID 1234567890` to point to your dependent application ID e.g. `#define APP_ID 14495`
+ - Change [line 3](https://github.com/resin-io-projects/micro-bit/blob/master/source/main.cpp#L3) in `source/main.cpp` `#define APP_ID 1234567890` to point to your dependent application ID e.g. `#define APP_ID 13829`
  - Run the provisioning script `$ ./provision.sh`, this will generate the initial firmware `micro-bit-combined.hex`
  - Connect the micro:bit to your computer using a USB cable
  - Copy `micro-bit-combined.hex` to your micro:bit


### PR DESCRIPTION
Make the comment match the URL when describing how to find the application ID