### PR TITLE
Implement multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # micro-bit base image
 # See more about resin base images here: http://docs.resin.io/runtime/resin-base-images/
-FROM resin/microbit
+FROM resin/microbit AS buildstep
 
 # Set the working directory
 WORKDIR /usr/src/app
@@ -14,3 +14,9 @@ COPY source/ ./source
 # Compile the firmware
 RUN yt build && \
     nrfutil dfu genpkg --application build/bbc-microbit-classic-gcc/source/micro-bit.bin /assets/application.zip
+
+# Start with a minimal runtime container
+FROM alpine
+
+# Copy the compiled firmware into the empty runtime container
+COPY --from=buildstep /assets/application.zip /assets/application.zip


### PR DESCRIPTION
Implement multi-stage builds, reducing the final container size down to less than 4MB